### PR TITLE
Install chartmuseum as part of bootstrap

### DIFF
--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -363,7 +363,10 @@ func (r *runner) installOperator(ctx context.Context, helmClient helmclient.Inte
 			namespace,
 			nil,
 			opts)
-		if helmclient.IsReleaseAlreadyExists(err) {
+		if helmclient.IsCannotReuseRelease(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q already installed", name))
+			return nil
+		} else if helmclient.IsReleaseAlreadyExists(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q already installed", name))
 			return nil
 		} else if err != nil {

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -122,6 +122,11 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 
+	err = r.installAppCatalogs(ctx, k8sClients)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	err = r.installChartMuseum(ctx, k8sClients)
 	if err != nil {
 		return microerror.Mask(err)
@@ -226,7 +231,7 @@ func (r *runner) ensurePriorityClass(ctx context.Context, k8sClients k8sclient.I
 	return nil
 }
 
-func (r *runner) installChartMuseum(ctx context.Context, k8sClients k8sclient.Interface) error {
+func (r *runner) installAppCatalogs(ctx context.Context, k8sClients k8sclient.Interface) error {
 	var err error
 
 	catalogs := map[string]string{
@@ -263,6 +268,12 @@ func (r *runner) installChartMuseum(ctx context.Context, k8sClients k8sclient.In
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created %#q appcatalog cr", name))
 	}
+
+	return nil
+}
+
+func (r *runner) installChartMuseum(ctx context.Context, k8sClients k8sclient.Interface) error {
+	var err error
 
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating %#q app cr", chartMuseumName))

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"time"
 
+	"github.com/giantswarm/apiextensions/v2/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/apiextensions/v2/pkg/crd"
+	"github.com/giantswarm/apiextensions/v2/pkg/label"
 	"github.com/giantswarm/appcatalog"
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/helmclient/v2/pkg/helmclient"
@@ -25,10 +27,15 @@ import (
 )
 
 const (
-	appOperatorVersion                = "2.2.0"
-	chartOperatorVersion              = "2.3.1"
-	controlPlaneTestCatalogStorageURL = "https://giantswarm.github.io/control-plane-catalog/"
-	namespace                         = "giantswarm"
+	appOperatorVersion            = "2.2.0"
+	chartMuseumName               = "chartmuseum"
+	chartMuseumCatalogStorageURL  = "http://chartmuseum-chartmuseum.giantswarm.svc.cluster.local:8080/charts/"
+	chartMuseumVersion            = "2.13.3"
+	chartOperatorVersion          = "2.3.1"
+	controlPlaneCatalogStorageURL = "https://giantswarm.github.io/control-plane-catalog/"
+	helmStableCatalogName         = "helm-stable"
+	helmStableCatalogStorageURL   = "https://kubernetes-charts.storage.googleapis.com/"
+	namespace                     = "giantswarm"
 )
 
 type runner struct {
@@ -111,6 +118,11 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	}
 
 	err = r.installOperators(ctx, helmClient)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.installChartMuseum(ctx, k8sClients)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -214,6 +226,80 @@ func (r *runner) ensurePriorityClass(ctx context.Context, k8sClients k8sclient.I
 	return nil
 }
 
+func (r *runner) installChartMuseum(ctx context.Context, k8sClients k8sclient.Interface) error {
+	var err error
+
+	catalogs := map[string]string{
+		chartMuseumName:       chartMuseumCatalogStorageURL,
+		helmStableCatalogName: helmStableCatalogStorageURL,
+	}
+
+	for name, url := range catalogs {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating %#q appcatalog cr", name))
+
+		appCatalogCR := &v1alpha1.AppCatalog{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					// Processed by app-operator-unique.
+					label.AppOperatorVersion: "0.0.0",
+				},
+			},
+			Spec: v1alpha1.AppCatalogSpec{
+				Description: name,
+				Title:       name,
+				Storage: v1alpha1.AppCatalogSpecStorage{
+					Type: "helm",
+					URL:  url,
+				},
+			},
+		}
+		_, err = k8sClients.G8sClient().ApplicationV1alpha1().AppCatalogs().Create(ctx, appCatalogCR, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q appcatalog CR already exists", appCatalogCR.Name))
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created %#q appcatalog cr", name))
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating %#q app cr", chartMuseumName))
+
+		appCR := &v1alpha1.App{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      chartMuseumName,
+				Namespace: namespace,
+				Labels: map[string]string{
+					// Processed by app-operator-unique.
+					label.AppOperatorVersion: "0.0.0",
+				},
+			},
+			Spec: v1alpha1.AppSpec{
+				Catalog: helmStableCatalogName,
+				KubeConfig: v1alpha1.AppSpecKubeConfig{
+					InCluster: true,
+				},
+				Name:      chartMuseumName,
+				Namespace: namespace,
+				Version:   chartMuseumVersion,
+			},
+		}
+		_, err = k8sClients.G8sClient().ApplicationV1alpha1().Apps(namespace).Create(ctx, appCR, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q app CR already exists", appCR.Name))
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created %#q app cr", chartMuseumName))
+	}
+
+	return nil
+}
+
 func (r *runner) installOperators(ctx context.Context, helmClient helmclient.Interface) error {
 	var err error
 
@@ -239,7 +325,7 @@ func (r *runner) installOperator(ctx context.Context, helmClient helmclient.Inte
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("getting tarball URL for %#q", name))
 
-		operatorTarballURL, err := appcatalog.GetLatestChart(ctx, controlPlaneTestCatalogStorageURL, name, version)
+		operatorTarballURL, err := appcatalog.GetLatestChart(ctx, controlPlaneCatalogStorageURL, name, version)
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
@piontec Since we discussed in sig-releng sync this is the new CLI. @glitchcrab you might also be interested.

It already bootstraps app-operator and chart-operator. This also installs chartmuseum from helm-stable.

The CLI just takes in a kubeconfig so I hope it can be integrated with KAT to do the bootstrapping.


```
$ kind create cluster
$ apptestctl bootstrap --kubeconfig="$(kind get kubeconfig)" | luigi

Deleting cluster "kind" ...
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.18.2) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-kind"
You can now use your cluster with:

kubectl cluster-info --context kind-kind

Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/
D 09/18 09:43:01 creating REST config from kubeconfig | k8sclient/v4/pkg/k8srestconfig/rest_config.go:137
D 09/18 09:43:01 created REST config from kubeconfig | k8sclient/v4/pkg/k8srestconfig/rest_config.go:145
D 09/18 09:43:01 ensuring `AppCatalog` CRD | apptestctl/cmd/bootstrap/runner.go:143
D 09/18 09:43:01 creating CRD `appcatalogs.application.giantswarm.io` | k8sclient/v4/pkg/k8scrdclient/crd_client.go:89
D 09/18 09:43:01 created CRD `appcatalogs.application.giantswarm.io` | k8sclient/v4/pkg/k8scrdclient/crd_client.go:100
D 09/18 09:43:01 updating CRD `appcatalogs.application.giantswarm.io` | k8sclient/v4/pkg/k8scrdclient/crd_client.go:124
D 09/18 09:43:02 updating CRD `appcatalogs.application.giantswarm.io` | k8sclient/v4/pkg/k8scrdclient/crd_client.go:124
D 09/18 09:43:03 updated CRD `appcatalogs.application.giantswarm.io` | k8sclient/v4/pkg/k8scrdclient/crd_client.go:137
D 09/18 09:43:03 ensured `AppCatalog` CRD exists | apptestctl/cmd/bootstrap/runner.go:150
D 09/18 09:43:03 ensuring `App` CRD | apptestctl/cmd/bootstrap/runner.go:143
D 09/18 09:43:03 creating CRD `apps.application.giantswarm.io` | k8sclient/v4/pkg/k8scrdclient/crd_client.go:89
D 09/18 09:43:03 created CRD `apps.application.giantswarm.io` | k8sclient/v4/pkg/k8scrdclient/crd_client.go:100
D 09/18 09:43:03 updating CRD `apps.application.giantswarm.io` | k8sclient/v4/pkg/k8scrdclient/crd_client.go:124
D 09/18 09:43:03 updated CRD `apps.application.giantswarm.io` | k8sclient/v4/pkg/k8scrdclient/crd_client.go:137
D 09/18 09:43:03 ensured `App` CRD exists | apptestctl/cmd/bootstrap/runner.go:150
D 09/18 09:43:03 ensuring `Chart` CRD | apptestctl/cmd/bootstrap/runner.go:143
D 09/18 09:43:03 creating CRD `charts.application.giantswarm.io` | k8sclient/v4/pkg/k8scrdclient/crd_client.go:89
D 09/18 09:43:03 created CRD `charts.application.giantswarm.io` | k8sclient/v4/pkg/k8scrdclient/crd_client.go:100
D 09/18 09:43:03 updating CRD `charts.application.giantswarm.io` | k8sclient/v4/pkg/k8scrdclient/crd_client.go:124
D 09/18 09:43:05 updating CRD `charts.application.giantswarm.io` | k8sclient/v4/pkg/k8scrdclient/crd_client.go:124
D 09/18 09:43:05 updated CRD `charts.application.giantswarm.io` | k8sclient/v4/pkg/k8scrdclient/crd_client.go:137
D 09/18 09:43:05 ensured `Chart` CRD exists | apptestctl/cmd/bootstrap/runner.go:150
D 09/18 09:43:05 creating priorityclass `giantswarm-critical` | apptestctl/cmd/bootstrap/runner.go:205
D 09/18 09:43:05 created priorityclass `giantswarm-critical` | apptestctl/cmd/bootstrap/runner.go:223
D 09/18 09:43:05 ensuring namespace `giantswarm` | apptestctl/cmd/bootstrap/runner.go:160
D 09/18 09:43:05 ensured namespace `giantswarm` | apptestctl/cmd/bootstrap/runner.go:197
D 09/18 09:43:05 getting tarball URL for `chart-operator` | apptestctl/cmd/bootstrap/runner.go:326
D 09/18 09:43:05 tarball URL is `https://giantswarm.github.com/control-plane-catalog/chart-operator-2.3.1.tgz` | apptestctl/cmd/bootstrap/runner.go:333
D 09/18 09:43:05 pulling tarball | apptestctl/cmd/bootstrap/runner.go:335
D 09/18 09:43:06 tarball path is `/var/folders/w1/x1v98z3d05bdy21_yn5ncpk40000gp/T/chart-tarball709393441` | apptestctl/cmd/bootstrap/runner.go:342
D 09/18 09:43:06 installing `chart-operator` | apptestctl/cmd/bootstrap/runner.go:354
D 09/18 09:43:07 installed `chart-operator` | apptestctl/cmd/bootstrap/runner.go:373
D 09/18 09:43:07 getting tarball URL for `app-operator` | apptestctl/cmd/bootstrap/runner.go:326
D 09/18 09:43:07 tarball URL is `https://giantswarm.github.com/control-plane-catalog/app-operator-2.2.0.tgz` | apptestctl/cmd/bootstrap/runner.go:333
D 09/18 09:43:07 pulling tarball | apptestctl/cmd/bootstrap/runner.go:335
D 09/18 09:43:08 tarball path is `/var/folders/w1/x1v98z3d05bdy21_yn5ncpk40000gp/T/chart-tarball491997964` | apptestctl/cmd/bootstrap/runner.go:342
D 09/18 09:43:08 installing `app-operator` | apptestctl/cmd/bootstrap/runner.go:354
D 09/18 09:43:09 installed `app-operator` | apptestctl/cmd/bootstrap/runner.go:373
D 09/18 09:43:09 creating `chartmuseum` appcatalog cr | apptestctl/cmd/bootstrap/runner.go:238
D 09/18 09:43:09 created `chartmuseum` appcatalog cr | apptestctl/cmd/bootstrap/runner.go:264
D 09/18 09:43:09 creating `helm-stable` appcatalog cr | apptestctl/cmd/bootstrap/runner.go:238
D 09/18 09:43:09 created `helm-stable` appcatalog cr | apptestctl/cmd/bootstrap/runner.go:264
D 09/18 09:43:09 creating `chartmuseum` app cr | apptestctl/cmd/bootstrap/runner.go:268
D 09/18 09:43:09 created `chartmuseum` app cr | apptestctl/cmd/bootstrap/runner.go:297
```