### PR TITLE
Add install-operators flag and create appcatalogentry CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add install operators flag.
+- Create AppCatalogEntry CRD.
+
 ## [0.2.0] - 2020-10-01
 
 ### Added

--- a/cmd/bootstrap/flag.go
+++ b/cmd/bootstrap/flag.go
@@ -7,14 +7,17 @@ import (
 )
 
 const (
-	kubeconfig = "kubeconfig"
+	installOperators = "install-operators"
+	kubeconfig       = "kubeconfig"
 )
 
 type flag struct {
-	KubeConfig string
+	InstallOperators bool
+	KubeConfig       string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(&f.InstallOperators, installOperators, "o", true, "Install app-operator and chart-operator")
 	cmd.Flags().StringVarP(&f.KubeConfig, kubeconfig, "k", "", "Explicit kubeconfig for the target cluster")
 }
 

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -130,9 +130,13 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 
-	err = r.installOperators(ctx, helmClient)
-	if err != nil {
-		return microerror.Mask(err)
+	if r.flag.InstallOperators {
+		err = r.installOperators(ctx, helmClient)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "skipping installing operators")
 	}
 
 	err = r.installAppCatalogs(ctx, k8sClients)

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -151,6 +151,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 func (r *runner) ensureCRDs(ctx context.Context, k8sClients k8sclient.Interface) error {
 	// Ensure Application group CRDs are created.
 	crds := []string{
+		"AppCatalogEntry",
 		"AppCatalog",
 		"App",
 		"Chart",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/giantswarm/apptestctl
 go 1.14
 
 require (
-	github.com/giantswarm/apiextensions/v2 v2.4.0
+	github.com/giantswarm/apiextensions/v2 v2.5.4-0.20201002123447-c595b53dd3aa
 	github.com/giantswarm/appcatalog v0.2.7
 	github.com/giantswarm/apptest v0.1.0
 	github.com/giantswarm/backoff v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/giantswarm/apptestctl
 go 1.14
 
 require (
-	github.com/giantswarm/apiextensions/v2 v2.5.4-0.20201002123447-c595b53dd3aa
+	github.com/giantswarm/apiextensions/v2 v2.6.0
 	github.com/giantswarm/appcatalog v0.2.7
-	github.com/giantswarm/apptest v0.1.0
+	github.com/giantswarm/apptest v0.2.0
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/helmclient/v2 v2.1.3
 	github.com/giantswarm/k8sclient/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/giantswarm/apiextensions/v2 v2.0.0/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
 github.com/giantswarm/apiextensions/v2 v2.4.0 h1:xHGA5cc0T2KEbOxHPAb8ZRbCUwpykHFYljKiyo+iSSw=
 github.com/giantswarm/apiextensions/v2 v2.4.0/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
+github.com/giantswarm/apiextensions/v2 v2.5.4-0.20201002123447-c595b53dd3aa h1:dMRHq7HBVyyo1pXwsD2qwD1ZG8VXyqbmZ23/9fZdQwM=
+github.com/giantswarm/apiextensions/v2 v2.5.4-0.20201002123447-c595b53dd3aa/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
 github.com/giantswarm/appcatalog v0.2.7 h1:SVD1OH/C5zEP8TaeS3L9t8+lVcfaRZhwY98sn8v9lYs=
 github.com/giantswarm/appcatalog v0.2.7/go.mod h1:WHO5lJvcuwzToxxHPdiX9CVxvMsmP8YZfjoo4E/NTLs=
 github.com/giantswarm/apptest v0.1.0 h1:tV1rIxMzXFuuMstOofh3IRE0NXCoqHR66EqR9Wb0uiM=

--- a/go.sum
+++ b/go.sum
@@ -221,12 +221,12 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/giantswarm/apiextensions/v2 v2.0.0/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
 github.com/giantswarm/apiextensions/v2 v2.4.0 h1:xHGA5cc0T2KEbOxHPAb8ZRbCUwpykHFYljKiyo+iSSw=
 github.com/giantswarm/apiextensions/v2 v2.4.0/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
-github.com/giantswarm/apiextensions/v2 v2.5.4-0.20201002123447-c595b53dd3aa h1:dMRHq7HBVyyo1pXwsD2qwD1ZG8VXyqbmZ23/9fZdQwM=
-github.com/giantswarm/apiextensions/v2 v2.5.4-0.20201002123447-c595b53dd3aa/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
+github.com/giantswarm/apiextensions/v2 v2.6.0 h1:a4sXl8x2QYccTUV9hSgkkerZNlyU8GHGRCFRPF5cGLc=
+github.com/giantswarm/apiextensions/v2 v2.6.0/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
 github.com/giantswarm/appcatalog v0.2.7 h1:SVD1OH/C5zEP8TaeS3L9t8+lVcfaRZhwY98sn8v9lYs=
 github.com/giantswarm/appcatalog v0.2.7/go.mod h1:WHO5lJvcuwzToxxHPdiX9CVxvMsmP8YZfjoo4E/NTLs=
-github.com/giantswarm/apptest v0.1.0 h1:tV1rIxMzXFuuMstOofh3IRE0NXCoqHR66EqR9Wb0uiM=
-github.com/giantswarm/apptest v0.1.0/go.mod h1:ziCoOxs9q70pwzpDXP9WpXnvg6JBg0WLTHi3s/MEJjk=
+github.com/giantswarm/apptest v0.2.0 h1:m91LAY3so4754wFy4OpNqlYyxLMe6WfksZQtJO04JkE=
+github.com/giantswarm/apptest v0.2.0/go.mod h1:L2lm6bAo4CAfXywFpU/QkA2Zy07wLp68dxwKG5cV/8o=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
 github.com/giantswarm/backoff v0.2.0/go.mod h1:Z3WRsFilSJ5H5VlFa4XhraoPr+9pmZgYasoY2OSfNOk=
 github.com/giantswarm/helmclient/v2 v2.1.3 h1:zbiJwH+lyQHA8Fq9yqHmxGhr3dnloJtGps0zSZjd9iM=


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10930

The new flag is so we can use apptestctl to bootstrap the kind clusters in app-operator and chart-operator tests. 

Also adds the appcatalogentry CRD so we can have a new test in app-operator for generating the CRs.

## Checklist

- [x] Update changelog in CHANGELOG.md.
