### PR TITLE
install psp for chartmuseum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Ensure PodSecurityPolicy for chartmuseum.
+- Enable ServiceAccount creation for chartmuseum.
 
 ## [0.3.1] - 2020-10-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ensure PodSecurityPolicy for chartmuseum.
+
 ## [0.3.1] - 2020-10-08
 
 ### Added

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -17,6 +17,7 @@ import (
 	"github.com/giantswarm/k8sclient/v4/pkg/k8srestconfig"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/to"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -300,8 +301,6 @@ func (r *runner) ensureChartMuseumPSP(ctx context.Context, k8sClients k8sclient.
 	name := "chartmuseum-psp"
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("ensuring psp %#q", name))
 
-	t := true
-
 	o := func() error {
 		{
 			clusterRole := &rbacv1.ClusterRole{
@@ -357,7 +356,7 @@ func (r *runner) ensureChartMuseumPSP(ctx context.Context, k8sClients k8sclient.
 					Name: name,
 				},
 				Spec: policyv1beta1.PodSecurityPolicySpec{
-					AllowPrivilegeEscalation: &t,
+					AllowPrivilegeEscalation: to.BoolP(true),
 					Volumes: []policyv1beta1.FSType{
 						policyv1beta1.All,
 					},

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/giantswarm/k8sclient/v4 v4.0.0
 	github.com/giantswarm/microerror v0.2.1
 	github.com/giantswarm/micrologger v0.3.3
+	github.com/giantswarm/to v0.3.0
 	github.com/spf13/afero v1.3.4
 	github.com/spf13/cobra v1.0.0
 	k8s.io/api v0.18.9

--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,8 @@ github.com/giantswarm/microerror v0.2.1/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e
 github.com/giantswarm/micrologger v0.3.1/go.mod h1:PjAgtcJ922ZMX/Aa05IPi0bdYvOj2P7pZ7+6dBShMQs=
 github.com/giantswarm/micrologger v0.3.3 h1:RGUOHlpFVvT9vK/BhZGqfzb9AjFxLLBns20oCdlTt8A=
 github.com/giantswarm/micrologger v0.3.3/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeVyhdHKblFX6QoMQ=
+github.com/giantswarm/to v0.3.0 h1:cEzMYkWLGI3cI8x3a0L3nPCQYJTb/cAaqcIPvxnDmpQ=
+github.com/giantswarm/to v0.3.0/go.mod h1:RTRtw+Dyk6YqoiNBOGLO981BqhibtVwogdaFIMO1y/A=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-acme/lego v2.5.0+incompatible/go.mod h1:yzMNe9CasVUhkquNvti5nAtPmG94USbYxYrZfTkIn0M=


### PR DESCRIPTION
This PR adds ensuring of a `ClusterRole`, `ClusterRoleBinding` and `PodSecurityPolicy` and enables `ServiceAccount` creation to make chartmuseum work on tenant clusters.

## Checklist

- [x] Update changelog in CHANGELOG.md.
