### PR TITLE
enable chartmuseum api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure PodSecurityPolicy for chartmuseum.
 - Enable ServiceAccount creation for chartmuseum.
+- Enable API of chartmuseum.
 
 ## [0.3.1] - 2020-10-08
 

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -407,7 +407,10 @@ func (r *runner) installChartMuseum(ctx context.Context, appTest apptest.Interfa
   enabled: "true"
 serviceAccount:
   name: "chartmuseum"
-  create: "true"`
+  create: "true"
+env:
+  open:
+    DISABLE_API: false`
 
 		apps := []apptest.App{
 			{


### PR DESCRIPTION
In order to have chartmuseum accept uploads through its api, the API must be enabled in the official upstream chartmuseum chart.

## Checklist

- [x] Update changelog in CHANGELOG.md.
