### PR TITLE
Add NetworkPolicy & Patch chart-operator deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure PodSecurityPolicy for chartmuseum.
 - Enable ServiceAccount creation for chartmuseum.
 - Enable API of chartmuseum.
-- Add container build through CircleCI.
+- Container build through CircleCI.
+- NetworkPolicy to enable communication with chartmuseum.
+- Patching dnsConfig and dnsPolicy of chart-operator-unique deployment.
 
 ## [0.3.1] - 2020-10-08
 

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -568,9 +568,8 @@ func (r *runner) patchChartOperatorDeployment(ctx context.Context, k8sClients k8
 
 	o := func() error {
 		list, err := k8sClients.K8sClient().AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
-
 		if apierrors.IsNotFound(err) || len(list.Items) != 1 {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "chart-operator deployment not ready yet")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "chart-operator deployment not created yet")
 			// fall through
 		} else if err != nil {
 			return microerror.Mask(err)
@@ -582,7 +581,6 @@ func (r *runner) patchChartOperatorDeployment(ctx context.Context, k8sClients k8
 		d.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
 
 		_, err = k8sClients.K8sClient().AppsV1().Deployments(namespace).Update(ctx, &d, metav1.UpdateOptions{})
-
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
This PR

- adds creating a NetworkPolicy for chartmuseum. Without it, communication with chartmuseum fails on tenant clusters
- changes the service url of chartmuseum to use the namespace-local url
- adds patching of the chart-operator-unique deployment to change how names are resolved. Otherwise the chartmuseum service url could not be resolved.

## Checklist

- [x] Update changelog in CHANGELOG.md.
