### PR TITLE
Patch DNS settings for chart-operator deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Patch dnsConfig and dnsPolicy of chart-operator-unique deployment.
+
 ## [0.4.0] - 2020-10-30
 
 ### Added

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"time"
@@ -28,6 +29,7 @@ import (
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
 )
@@ -143,7 +145,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	}
 
 	if r.flag.InstallOperators {
-		err = r.installOperators(ctx, helmClient)
+		err = r.installOperators(ctx, helmClient, k8sClients)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -484,7 +486,7 @@ env:
 	return nil
 }
 
-func (r *runner) installOperators(ctx context.Context, helmClient helmclient.Interface) error {
+func (r *runner) installOperators(ctx context.Context, helmClient helmclient.Interface, k8sClients k8sclient.Interface) error {
 	var err error
 
 	operators := map[string]string{
@@ -494,6 +496,11 @@ func (r *runner) installOperators(ctx context.Context, helmClient helmclient.Int
 
 	for name, version := range operators {
 		err = r.installOperator(ctx, helmClient, name, version)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		err = r.patchChartOperatorDeployment(ctx, k8sClients)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -559,6 +566,55 @@ func (r *runner) installOperator(ctx context.Context, helmClient helmclient.Inte
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installed %#q", name))
 	}
+
+	return nil
+}
+
+func (r *runner) patchChartOperatorDeployment(ctx context.Context, k8sClients k8sclient.Interface) error {
+	labelSelector := "app.kubernetes.io/instance=chart-operator-unique"
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for chart-operator with label selector %#q", labelSelector))
+
+	o := func() error {
+		list, err := k8sClients.K8sClient().AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if apierrors.IsNotFound(err) || len(list.Items) != 1 {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "chart-operator deployment not created yet")
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		patches := []Patch{
+			{
+				Op:   "remove",
+				Path: "/spec/template/spec/dnsConfig",
+			},
+			{
+				Op:    "replace",
+				Path:  "/spec/template/spec/dnsPolicy",
+				Value: "ClusterFirst",
+			},
+		}
+
+		bytes, err := json.Marshal(patches)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		_, err = k8sClients.K8sClient().AppsV1().Deployments(namespace).Patch(ctx, list.Items[0].Name, types.JSONPatchType, bytes, metav1.PatchOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		return nil
+	}
+	b := backoff.NewExponential(backoff.ShortMaxWait, backoff.ShortMaxInterval)
+
+	err := backoff.Retry(o, b)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("patching deployment for chart-operator with name %#q done", ""))
 
 	return nil
 }

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -578,9 +578,7 @@ func (r *runner) patchChartOperatorDeployment(ctx context.Context, k8sClients k8
 
 	o := func() error {
 		deploy, err := k8sClients.K8sClient().AppsV1().Deployments(namespace).Get(ctx, chartOperatorDeployment, metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			return microerror.Maskf(executionFailedError, "deployment %#q in %#q not found", chartOperatorDeployment, namespace)
-		} else if err != nil {
+		if err != nil {
 			return microerror.Mask(err)
 		}
 

--- a/integration/test/bootstrap/setup.sh
+++ b/integration/test/bootstrap/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Start the bootstrap process.
-make
-./apptestctl bootstrap --kubeconfig="$(kind get kubeconfig)"
+go install .
+apptestctl bootstrap --kubeconfig="$(kind get kubeconfig)"

--- a/integration/test/bootstrap/setup.sh
+++ b/integration/test/bootstrap/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Start the bootstrap process.
-make
+go install .
 apptestctl bootstrap --kubeconfig="$(kind get kubeconfig)"

--- a/integration/test/bootstrap/setup.sh
+++ b/integration/test/bootstrap/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Start the bootstrap process.
-go install .
+make
 apptestctl bootstrap --kubeconfig="$(kind get kubeconfig)"


### PR DESCRIPTION
The DNS settings need to be patched or the status webhook fails. This slows down the tests as you need to wait for the resync period to set the app CR status.


## Checklist

- [x] Update changelog in CHANGELOG.md.
