### PR TITLE
allow overwriting charts in chart-museum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart-museum is now deployed with "allow-overwrite" option, so the same chart may be uploaded multiple times.
+
 ## [0.5.1] - 2020-11-30
 
 ### Added

--- a/cmd/bootstrap/template.go
+++ b/cmd/bootstrap/template.go
@@ -8,6 +8,7 @@ serviceAccount:
   create: "true"
 env:
   open:
+    ALLOW_OVERWRITE: true
     DISABLE_API: false`
 
 	operatorValuesYAML string = `Installation:


### PR DESCRIPTION
Without it, it's hard for tests to easily reuse some setup logic. Should do no harm in testing scenarios.
