### PR TITLE
Deleting merge functions from apptestctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove helmclient.MergeValue functions usage.
+
 ## [0.5.2] - 2020-12-01
 
 ### Changed

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -568,11 +568,9 @@ func (r *runner) installOperator(ctx context.Context, helmClient helmclient.Inte
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installing %#q", name))
 
 		// Set control plane operator values so chart-operator DNS settings are
-		// correct. Merge with an empty set of values so YAML is parsed.
-		input := map[string][]byte{
-			"values": []byte(operatorValuesYAML),
-		}
-		values, err := helmclient.MergeValues(input, map[string][]byte{})
+		// correct.
+		var input map[string]interface{}
+		err := yaml.Unmarshal([]byte(operatorValuesYAML), &input)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -587,7 +585,7 @@ func (r *runner) installOperator(ctx context.Context, helmClient helmclient.Inte
 		err = helmClient.InstallReleaseFromTarball(ctx,
 			operatorTarballPath,
 			namespace,
-			values,
+			input,
 			opts)
 		if helmclient.IsCannotReuseRelease(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q already installed", name))

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -570,6 +570,7 @@ func (r *runner) installOperator(ctx context.Context, helmClient helmclient.Inte
 		// Set control plane operator values so chart-operator DNS settings are
 		// correct.
 		var input map[string]interface{}
+		
 		err := yaml.Unmarshal([]byte(operatorValuesYAML), &input)
 		if err != nil {
 			return microerror.Mask(err)

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -570,7 +570,7 @@ func (r *runner) installOperator(ctx context.Context, helmClient helmclient.Inte
 		// Set control plane operator values so chart-operator DNS settings are
 		// correct.
 		var input map[string]interface{}
-		
+
 		err := yaml.Unmarshal([]byte(operatorValuesYAML), &input)
 		if err != nil {
 			return microerror.Mask(err)


### PR DESCRIPTION
Deleting `helmclient.Merge` from apptestctl so we can deprecate that function. 