### PR TITLE
Update app-operator and chart-operator versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update app-operator to v4.0.0.
+- Update chart-operator to v2.9.0.
+
 ## [0.6.1] - 2021-01-11
 
 ### Fixed

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -37,11 +37,11 @@ import (
 )
 
 const (
-	appOperatorVersion            = "3.0.0"
+	appOperatorVersion            = "4.0.0"
 	chartMuseumName               = "chartmuseum"
 	chartMuseumCatalogStorageURL  = "http://chartmuseum-chartmuseum:8080/charts/"
 	chartMuseumVersion            = "2.13.3"
-	chartOperatorVersion          = "2.4.0"
+	chartOperatorVersion          = "2.9.0"
 	controlPlaneCatalogStorageURL = "https://giantswarm.github.io/control-plane-catalog/"
 	helmStableCatalogName         = "helm-stable"
 	helmStableCatalogStorageURL   = "https://charts.helm.sh/stable/packages/"


### PR DESCRIPTION
Updates to the latest app-operator which gets rid of the status webhook and ingress. chart-operator also misses some fixes.


## Checklist

- [x] Update changelog in CHANGELOG.md.
