### PR TITLE
Update app-operator and chart-operator for K8s 1.20 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update app-operator to v4.0.2.
+- Update app-operator to v4.3.2 for Kubernetes 1.20 support.
+- Update chart-operator to v2.13.1 for Kubernetes 1.20 support.
 
 ## [0.7.0] - 2021-02-24
 

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -37,11 +37,11 @@ import (
 )
 
 const (
-	appOperatorVersion            = "4.0.2"
+	appOperatorVersion            = "4.3.2"
 	chartMuseumName               = "chartmuseum"
 	chartMuseumCatalogStorageURL  = "http://chartmuseum-chartmuseum:8080/charts/"
 	chartMuseumVersion            = "2.13.3"
-	chartOperatorVersion          = "2.9.0"
+	chartOperatorVersion          = "2.13.1"
 	controlPlaneCatalogStorageURL = "https://giantswarm.github.io/control-plane-catalog/"
 	helmStableCatalogName         = "helm-stable"
 	helmStableCatalogStorageURL   = "https://charts.helm.sh/stable/packages/"


### PR DESCRIPTION
Fixes https://github.com/giantswarm/apptestctl/issues/111

Removes usage of self link so we don't need feature flags with kind.

## Checklist

- [x] Update changelog in CHANGELOG.md.
