### PR TITLE
Embed CRDs to avoid hitting GitHub API rate limits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@4.3.0
+  architect: giantswarm/architect@4.6.0
 
 workflows:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Embed `application.giantswarm.io` CRDs to avoid hitting GitHub API rate limits.
+
 ## [0.11.1] - 2021-09-28
 
 ### Fixed

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,0 +1,6 @@
+# Directories.
+SCRIPTS_DIR := hack
+
+sync-crds:
+	@echo "$(GEN_COLOR)Syncing Application CRDs with apiextensions$(NO_COLOR)"
+	cd $(SCRIPTS_DIR); ./sync-crds.sh

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ the trick. Alternatively the following one-liner may help.
 GO111MODULE=on go install -ldflags "-X 'github.com/giantswarm/apptestctl/pkg/project.gitSHA=$(git rev-parse HEAD)'" .
 ```
 
-# Usage
+## Usage
 
 After creating a [kind](https://kind.sigs.k8s.io/) cluster on your local machine, type below command. 
 
@@ -23,9 +23,22 @@ apptestctl bootstrap --kubeconfig="$(kind get kubeconfig)"
 
 {"caller":"github.com/giantswarm/k8sclient/v5/pkg/k8srestconfig/rest_config.go:137","level":"debug","message":"creating REST config from kubeconfig","time":"2020-09-29T11:09:41.587218+00:00"}
 {"caller":"github.com/giantswarm/k8sclient/v5/pkg/k8srestconfig/rest_config.go:145","level":"debug","message":"created REST config from kubeconfig","time":"2020-09-29T11:09:41.588999+00:00"}
-{"caller":"github.com/giantswarm/apptestctl/cmd/bootstrap/runner.go:148","level":"debug","message":"ensuring `AppCatalog` CRD","time":"2020-09-29T11:09:41.651762+00:00"}
-{"caller":"github.com/giantswarm/k8sclient/v5/pkg/k8scrdclient/crd_client.go:89","level":"debug","message":"creating CRD `appcatalogs.application.giantswarm.io`","time":"2020-09-29T11:09:41.726147+00:00"}
 ...
 ```
 
 It will automatically create all resources such as app-operator, chart-operator and CRDs for app testing.
+
+## Update CRDs
+
+The bootstrap command installs CRDs in the group `application.giantswarm.io`.
+These are embedded in `pkg/crds` to avoid hitting GitHub API rate limits.
+
+The CRD manifests can be updated with this snippet.
+
+```sh
+crds=( appcatalogentries appcatalogs apps catalogs charts )
+
+for crd in "${crds[@]}"; do
+        curl -s "https://raw.githubusercontent.com/giantswarm/apiextensions/master/config/crd/application.giantswarm.io_${crd}.yaml" > "pkg/crds/${crd}.yaml"
+done
+```

--- a/README.md
+++ b/README.md
@@ -33,12 +33,9 @@ It will automatically create all resources such as app-operator, chart-operator 
 The bootstrap command installs CRDs in the group `application.giantswarm.io`.
 These are embedded in `pkg/crds` to avoid hitting GitHub API rate limits.
 
-The CRD manifests can be updated with this snippet.
+The CRD manifests can be synced with [apiextensions](https://github.com/giantswarm/apiextensions)
+using the Makefile.
 
 ```sh
-crds=( appcatalogentries appcatalogs apps catalogs charts )
-
-for crd in "${crds[@]}"; do
-        curl -s "https://raw.githubusercontent.com/giantswarm/apiextensions/master/config/crd/application.giantswarm.io_${crd}.yaml" > "pkg/crds/${crd}.yaml"
-done
+make sync-crds
 ```

--- a/cmd/bootstrap/flag.go
+++ b/cmd/bootstrap/flag.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-	githubToken      = "github-token"
 	installOperators = "install-operators"
 	kubeconfig       = "kubeconfig"
 	kubeconfigEnvVar = "KUBECONFIG"
@@ -17,7 +16,6 @@ const (
 )
 
 type flag struct {
-	GithubToken      string
 	InstallOperators bool
 	KubeConfig       string
 	KubeConfigPath   string
@@ -25,7 +23,6 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&f.GithubToken, githubToken, "g", "", "Github Token for fetching CRDs")
 	cmd.Flags().BoolVarP(&f.InstallOperators, installOperators, "o", true, "Install app-operator and chart-operator")
 	cmd.Flags().StringVarP(&f.KubeConfig, kubeconfig, "k", "", "Explicit kubeconfig for the target cluster")
 	cmd.Flags().StringVarP(&f.KubeConfigPath, kubeconfigPath, "p", "", "Path to a kubeconfig file for the target cluster")

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.16
 
 require (
 	github.com/giantswarm/apiextensions/v3 v3.32.0
-	github.com/giantswarm/app/v5 v5.2.3
 	github.com/giantswarm/appcatalog v0.6.0
 	github.com/giantswarm/apptest v0.12.0
 	github.com/giantswarm/backoff v0.2.0
@@ -16,6 +15,7 @@ require (
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.2.1
 	k8s.io/api v0.20.10
+	k8s.io/apiextensions-apiserver v0.20.10
 	k8s.io/apimachinery v0.20.10
 	k8s.io/client-go v0.20.10
 	sigs.k8s.io/yaml v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,6 @@ github.com/giantswarm/apiextensions/v3 v3.30.0/go.mod h1:PcU7LAi0E8lOXoPp2wD7AY/
 github.com/giantswarm/apiextensions/v3 v3.32.0 h1:lutZ2Fa+m0pUXl9F6CdrhpRmnBvk5FSbx+Amakdflbc=
 github.com/giantswarm/apiextensions/v3 v3.32.0/go.mod h1:PcU7LAi0E8lOXoPp2wD7AY/AOtp6sN03cnQuBZGAksg=
 github.com/giantswarm/app/v5 v5.2.2/go.mod h1:2JiVuuz/uQ+L33nxmyAv+PJanq8oeEGuVA6mA0396Fk=
-github.com/giantswarm/app/v5 v5.2.3 h1:6Zqgy8i3p5n2C696xRyzmSSPhx5F3FNZPFffF+P9Ha4=
-github.com/giantswarm/app/v5 v5.2.3/go.mod h1:2JiVuuz/uQ+L33nxmyAv+PJanq8oeEGuVA6mA0396Fk=
 github.com/giantswarm/appcatalog v0.6.0 h1:lJMmiPK2pyWQtOaLlBwq0Ut1XrMhcnGeA+3j4OMHyfU=
 github.com/giantswarm/appcatalog v0.6.0/go.mod h1:MaglaykZAeFukjpD/jVHrm/zZFwa9uusuN6BgT4NXpY=
 github.com/giantswarm/apptest v0.12.0 h1:iKqUuhUamy9SaONo18/9J+dcuxg3qr3Y/UfXeVv3uMk=
@@ -461,11 +459,8 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
-github.com/google/go-github/v35 v35.2.0 h1:s/soW8jauhjUC3rh8JI0FePuocj0DEI9DNBg/bVplE8=
 github.com/google/go-github/v35 v35.2.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
-github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/hack/sync-crds.sh
+++ b/hack/sync-crds.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+crds=( appcatalogentries appcatalogs apps catalogs charts )
+
+for crd in "${crds[@]}"; do
+        curl -s "https://raw.githubusercontent.com/giantswarm/apiextensions/master/config/crd/application.giantswarm.io_${crd}.yaml" > "../pkg/crds/${crd}.yaml"
+done

--- a/pkg/crds/appcatalogentries.yaml
+++ b/pkg/crds/appcatalogentries.yaml
@@ -1,0 +1,191 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: appcatalogentries.application.giantswarm.io
+spec:
+  group: application.giantswarm.io
+  names:
+    categories:
+    - common
+    - giantswarm
+    kind: AppCatalogEntry
+    listKind: AppCatalogEntryList
+    plural: appcatalogentries
+    shortNames:
+    - ace
+    - aces
+    singular: appcatalogentry
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Catalog this entry belongs to
+      jsonPath: .spec.catalog.name
+      name: Catalog
+      type: string
+    - description: App this entry belongs to
+      jsonPath: .spec.appName
+      name: App Name
+      type: string
+    - description: Upstream version of the app for this entry
+      jsonPath: .spec.appVersion
+      name: App Version
+      type: string
+    - description: Version of the app for this entry
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Time since entry was first created
+      jsonPath: .spec.dateCreated
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AppCatalogEntry represents an entry of an app in a catalog of
+          managed apps. It stores metadata for specific versions and apps. It is generated
+          by app-operator and consumed by app-admission-controller.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              appName:
+                description: AppName is the name of the app this entry belongs to.
+                  e.g. nginx-ingress-controller-app
+                type: string
+              appVersion:
+                description: AppVersion is the upstream version of the app for this
+                  entry. e.g. v0.35.0
+                type: string
+              catalog:
+                description: Catalog is the name of the app catalog this entry belongs
+                  to. e.g. giantswarm
+                properties:
+                  name:
+                    description: Name is the name of the app catalog this entry belongs
+                      to. e.g. giantswarm-catalog
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the catalog. It is
+                      empty while the appcatalog CRD is cluster scoped.
+                    type: string
+                required:
+                - name
+                type: object
+              chart:
+                description: Chart is metadata from the Chart.yaml of the app this
+                  entry belongs to.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the Helm chart API version.
+                    type: string
+                  description:
+                    description: Description is the Helm chart description.
+                    nullable: true
+                    type: string
+                  home:
+                    description: Home is the URL of this projects home page.
+                    nullable: true
+                    type: string
+                  icon:
+                    description: Icon is a URL to an SVG or PNG image to be used as
+                      an icon.
+                    nullable: true
+                    type: string
+                  keywords:
+                    description: Keywords is the keyword strings from the helm chart.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  upstreamChartVersion:
+                    description: UpstreamChartVersion is the original version of upstream
+                      chart in this app.
+                    nullable: true
+                    type: string
+                required:
+                - apiVersion
+                type: object
+              dateCreated:
+                description: DateCreated is when this entry was first created. e.g.
+                  2020-09-02T09:40:39.223638219Z
+                format: date-time
+                type: string
+              dateUpdated:
+                description: DateUpdated is when this entry was last updated. e.g.
+                  2020-09-02T09:40:39.223638219Z
+                format: date-time
+                type: string
+              restrictions:
+                description: Restrictions is metadata from Chart.yaml for this app
+                  and is used to validate app CRs.
+                nullable: true
+                properties:
+                  clusterSingleton:
+                    description: ClusterSingleton is a flag for whether this app can
+                      be installed at most once per cluster. Default is false.
+                    type: boolean
+                  compatibleProviders:
+                    description: CompatibleProviders is a list of provider names which
+                      this app is compatible with. Default is empty. Empty list means
+                      app is compatible with all providers.
+                    items:
+                      enum:
+                      - aws
+                      - azure
+                      - kvm
+                      type: string
+                    nullable: true
+                    type: array
+                  fixedNamespace:
+                    description: FixedNamespace is the namespace which this app must
+                      be installed in.
+                    type: string
+                  gpuInstances:
+                    description: GpuInstances is a flag for whether this app requires
+                      GPU instances to run. Default is false.
+                    type: boolean
+                  namespaceSingleton:
+                    description: NamespaceSingleton is a flag for whether this app
+                      can be installed at most once per namespace. Default is false.
+                    type: boolean
+                type: object
+              version:
+                description: Version is the version of the app chart for this entry.
+                  e.g. 1.9.2
+                type: string
+            required:
+            - appName
+            - appVersion
+            - catalog
+            - dateCreated
+            - dateUpdated
+            - version
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/crds/appcatalogs.yaml
+++ b/pkg/crds/appcatalogs.yaml
@@ -1,0 +1,125 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: appcatalogs.application.giantswarm.io
+spec:
+  group: application.giantswarm.io
+  names:
+    categories:
+    - common
+    - giantswarm
+    kind: AppCatalog
+    listKind: AppCatalogList
+    plural: appcatalogs
+    singular: appcatalog
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Deprecated, use Catalog CRD instead. AppCatalog represents a
+          catalog of managed apps. It stores general information for potential apps
+          to install. It is reconciled by app-operator.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              config:
+                description: Config is the config to be applied when apps belonging
+                  to this catalog are deployed.
+                nullable: true
+                properties:
+                  configMap:
+                    description: ConfigMap references a config map containing catalog
+                      values that should be applied to apps in this catalog.
+                    nullable: true
+                    properties:
+                      name:
+                        description: Name is the name of the config map containing
+                          catalog values to apply, e.g. app-catalog-values.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the catalog values
+                          config map, e.g. giantswarm.
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  secret:
+                    description: Secret references a secret containing catalog values
+                      that should be applied to apps in this catalog.
+                    nullable: true
+                    properties:
+                      name:
+                        description: Name is the name of the secret containing catalog
+                          values to apply, e.g. app-catalog-secret.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the secret, e.g.
+                          giantswarm.
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                type: object
+              description:
+                type: string
+              logoURL:
+                description: LogoURL contains the links for logo image file for this
+                  app catalog
+                type: string
+              storage:
+                description: Storage references a map containing values that should
+                  be applied to the appcatalog.
+                properties:
+                  URL:
+                    description: URL is the link to where this AppCatalog's repository
+                      is located e.g. https://example.com/app-catalog/
+                    type: string
+                  type:
+                    description: Type indicates which repository type would be used
+                      for this AppCatalog. e.g. helm
+                    type: string
+                required:
+                - URL
+                - type
+                type: object
+              title:
+                description: Title is the name of the app catalog for this CR e.g.
+                  Catalog of Apps by Giant Swarm
+                type: string
+            required:
+            - description
+            - logoURL
+            - storage
+            - title
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/crds/apps.yaml
+++ b/pkg/crds/apps.yaml
@@ -1,0 +1,281 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: apps.application.giantswarm.io
+spec:
+  group: application.giantswarm.io
+  names:
+    categories:
+    - common
+    - giantswarm
+    kind: App
+    listKind: AppList
+    plural: apps
+    singular: app
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Version of the app
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Time since last deployment
+      jsonPath: .status.release.lastDeployed
+      name: Last Deployed
+      type: date
+    - description: Deployment status of the app
+      jsonPath: .status.release.status
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: App represents a managed app which a user intended to install.
+          It is reconciled by app-operator.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              catalog:
+                description: Catalog is the name of the app catalog this app belongs
+                  to. e.g. giantswarm
+                type: string
+              catalogNamespace:
+                description: CatalogNamespace is the namespace of the Catalog CR this
+                  app belongs to. e.g. giantswarm
+                nullable: true
+                type: string
+              config:
+                description: Config is the config to be applied when the app is deployed.
+                nullable: true
+                properties:
+                  configMap:
+                    description: ConfigMap references a config map containing values
+                      that should be applied to the app.
+                    nullable: true
+                    properties:
+                      name:
+                        description: Name is the name of the config map containing
+                          app values to apply, e.g. prometheus-values.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the values config
+                          map, e.g. monitoring.
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  secret:
+                    description: Secret references a secret containing secret values
+                      that should be applied to the app.
+                    nullable: true
+                    properties:
+                      name:
+                        description: Name is the name of the secret containing app
+                          values to apply, e.g. prometheus-secret.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the secret, e.g.
+                          kube-system.
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                type: object
+              install:
+                description: Install is the config used when installing the app.
+                nullable: true
+                properties:
+                  skipCRDs:
+                    description: 'SkipCRDs when true decides that CRDs which are supplied
+                      with the chart are not installed. Default: false.'
+                    nullable: true
+                    type: boolean
+                type: object
+              kubeConfig:
+                description: KubeConfig is the kubeconfig to connect to the cluster
+                  when deploying the app.
+                properties:
+                  context:
+                    description: Context is the kubeconfig context.
+                    nullable: true
+                    properties:
+                      name:
+                        description: Name is the name of the kubeconfig context. e.g.
+                          giantswarm-12345.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  inCluster:
+                    description: InCluster is a flag for whether to use InCluster
+                      credentials. When true the context name and secret should not
+                      be set.
+                    type: boolean
+                  secret:
+                    description: Secret references a secret containing the kubconfig.
+                    nullable: true
+                    properties:
+                      name:
+                        description: Name is the name of the secret containing the
+                          kubeconfig, e.g. app-operator-kubeconfig.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the secret containing
+                          the kubeconfig, e.g. giantswarm.
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                required:
+                - inCluster
+                type: object
+              name:
+                description: Name is the name of the app to be deployed. e.g. kubernetes-prometheus
+                type: string
+              namespace:
+                description: Namespace is the namespace where the app should be deployed.
+                  e.g. monitoring
+                type: string
+              namespaceConfig:
+                description: NamespaceConfig is the namespace config to be applied
+                  to the target namespace when the app is deployed.
+                nullable: true
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations is a string map of annotations to apply
+                      to the target namespace.
+                    nullable: true
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels is a string map of labels to apply to the
+                      target namespace.
+                    nullable: true
+                    type: object
+                type: object
+              userConfig:
+                description: UserConfig is the user config to be applied when the
+                  app is deployed.
+                nullable: true
+                properties:
+                  configMap:
+                    description: ConfigMap references a config map containing user
+                      values that should be applied to the app.
+                    nullable: true
+                    properties:
+                      name:
+                        description: Name is the name of the config map containing
+                          user values to apply, e.g. prometheus-user-values.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the user values
+                          config map on the management cluster, e.g. 123ab.
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  secret:
+                    description: Secret references a secret containing user secret
+                      values that should be applied to the app.
+                    nullable: true
+                    properties:
+                      name:
+                        description: Name is the name of the secret containing user
+                          values to apply, e.g. prometheus-user-secret.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the secret, e.g.
+                          kube-system.
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                type: object
+              version:
+                description: Version is the version of the app that should be deployed.
+                  e.g. 1.0.0
+                type: string
+            required:
+            - catalog
+            - kubeConfig
+            - name
+            - namespace
+            - version
+            type: object
+          status:
+            description: Status Spec part of the App resource. Initially, it would
+              be left as empty until the operator successfully reconciles the helm
+              release.
+            properties:
+              appVersion:
+                description: AppVersion is the value of the AppVersion field in the
+                  Chart.yaml of the deployed app. This is an optional field with the
+                  version of the component being deployed. e.g. 0.21.0. https://helm.sh/docs/topics/charts/#the-chartyaml-file
+                type: string
+              release:
+                description: Release is the status of the Helm release for the deployed
+                  app.
+                properties:
+                  lastDeployed:
+                    description: LastDeployed is the time when the app was last deployed.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  reason:
+                    description: Reason is the description of the last status of helm
+                      release when the app is not installed successfully, e.g. deploy
+                      resource already exists.
+                    type: string
+                  status:
+                    description: Status is the status of the deployed app, e.g. DEPLOYED.
+                    type: string
+                required:
+                - status
+                type: object
+              version:
+                description: Version is the value of the Version field in the Chart.yaml
+                  of the deployed app. e.g. 1.0.0.
+                type: string
+            required:
+            - appVersion
+            - release
+            - version
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/crds/catalogs.yaml
+++ b/pkg/crds/catalogs.yaml
@@ -1,0 +1,134 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: catalogs.application.giantswarm.io
+spec:
+  group: application.giantswarm.io
+  names:
+    categories:
+    - common
+    - giantswarm
+    kind: Catalog
+    listKind: CatalogList
+    plural: catalogs
+    singular: catalog
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: URL of the catalog
+      jsonPath: .spec.storage.URL
+      name: Catalog URL
+      type: string
+    - description: Time since created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Catalog represents a catalog of managed apps. It stores general
+          information for potential apps to install. It is reconciled by app-operator.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              config:
+                description: Config is the config to be applied when apps belonging
+                  to this catalog are deployed.
+                nullable: true
+                properties:
+                  configMap:
+                    description: ConfigMap references a config map containing catalog
+                      values that should be applied to apps in this catalog.
+                    nullable: true
+                    properties:
+                      name:
+                        description: Name is the name of the config map containing
+                          catalog values to apply, e.g. app-catalog-values.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the catalog values
+                          config map, e.g. giantswarm.
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  secret:
+                    description: Secret references a secret containing catalog values
+                      that should be applied to apps in this catalog.
+                    nullable: true
+                    properties:
+                      name:
+                        description: Name is the name of the secret containing catalog
+                          values to apply, e.g. app-catalog-secret.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the secret, e.g.
+                          giantswarm.
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                type: object
+              description:
+                type: string
+              logoURL:
+                description: LogoURL contains the links for logo image file for this
+                  catalog
+                type: string
+              storage:
+                description: Storage references a map containing values that should
+                  be applied to the catalog.
+                properties:
+                  URL:
+                    description: URL is the link to where this Catalog's repository
+                      is located e.g. https://example.com/app-catalog/
+                    type: string
+                  type:
+                    description: Type indicates which repository type would be used
+                      for this Catalog. e.g. helm
+                    type: string
+                required:
+                - URL
+                - type
+                type: object
+              title:
+                description: Title is the name of the catalog for this CR e.g. Catalog
+                  of Apps by Giant Swarm
+                type: string
+            required:
+            - description
+            - logoURL
+            - storage
+            - title
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/crds/charts.yaml
+++ b/pkg/crds/charts.yaml
@@ -1,0 +1,216 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: charts.application.giantswarm.io
+spec:
+  group: application.giantswarm.io
+  names:
+    categories:
+    - common
+    - giantswarm
+    kind: Chart
+    listKind: ChartList
+    plural: charts
+    singular: chart
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Version of the app
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Time since last deployment
+      jsonPath: .status.release.lastDeployed
+      name: Last Deployed
+      type: date
+    - description: Deployment status of the app
+      jsonPath: .status.release.status
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Chart represents a Helm chart to be deployed as a Helm release.
+          It is reconciled by chart-operator.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              config:
+                description: Config is the config to be applied when the chart is
+                  deployed.
+                nullable: true
+                properties:
+                  configMap:
+                    description: ConfigMap references a config map containing values
+                      that should be applied to the chart.
+                    nullable: true
+                    properties:
+                      name:
+                        description: Name is the name of the config map containing
+                          chart values to apply, e.g. prometheus-chart-values.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the values config
+                          map, e.g. monitoring.
+                        type: string
+                      resourceVersion:
+                        description: ResourceVersion is the Kubernetes resource version
+                          of the configmap. Used to detect if the configmap has changed,
+                          e.g. 12345.
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    - resourceVersion
+                    type: object
+                  secret:
+                    description: Secret references a secret containing secret values
+                      that should be applied to the chart.
+                    nullable: true
+                    properties:
+                      name:
+                        description: Name is the name of the secret containing chart
+                          values to apply, e.g. prometheus-chart-secret.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the secret, e.g.
+                          kube-system.
+                        type: string
+                      resourceVersion:
+                        description: ResourceVersion is the Kubernetes resource version
+                          of the secret. Used to detect if the secret has changed,
+                          e.g. 12345.
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    - resourceVersion
+                    type: object
+                type: object
+              install:
+                description: Install is the config used to deploy the app and is passed
+                  to Helm.
+                nullable: true
+                properties:
+                  skipCRDs:
+                    description: 'SkipCRDs when true decides that CRDs which are supplied
+                      with the chart are not installed. Default: false.'
+                    nullable: true
+                    type: boolean
+                type: object
+              name:
+                description: Name is the name of the Helm chart to be deployed. e.g.
+                  kubernetes-prometheus
+                type: string
+              namespace:
+                description: Namespace is the namespace where the chart should be
+                  deployed. e.g. monitoring
+                type: string
+              namespaceConfig:
+                description: NamespaceConfig is the namespace config to be applied
+                  to the target namespace when the chart is deployed.
+                nullable: true
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations is a string map of annotations to apply
+                      to the target namespace.
+                    nullable: true
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels is a string map of labels to apply to the
+                      target namespace.
+                    nullable: true
+                    type: object
+                type: object
+              tarballURL:
+                description: TarballURL is the URL for the Helm chart tarball to be
+                  deployed. e.g. https://example.com/path/to/prom-1-0-0.tgz
+                type: string
+              version:
+                description: Version is the version of the chart that should be deployed.
+                  e.g. 1.0.0
+                type: string
+            required:
+            - name
+            - namespace
+            - tarballURL
+            - version
+            type: object
+          status:
+            properties:
+              appVersion:
+                description: AppVersion is the value of the AppVersion field in the
+                  Chart.yaml of the deployed chart. This is an optional field with
+                  the version of the component being deployed. e.g. 0.21.0. https://helm.sh/docs/topics/charts/#the-chartyaml-file
+                type: string
+              reason:
+                description: Reason is the description of the last status of helm
+                  release when the chart is not installed successfully, e.g. deploy
+                  resource already exists.
+                type: string
+              release:
+                description: Release is the status of the Helm release for the deployed
+                  chart.
+                properties:
+                  lastDeployed:
+                    description: LastDeployed is the time when the deployed chart
+                      was last deployed.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  revision:
+                    description: Revision is the revision number for this deployed
+                      chart.
+                    nullable: true
+                    type: integer
+                  status:
+                    description: Status is the status of the deployed chart, e.g.
+                      DEPLOYED.
+                    type: string
+                required:
+                - status
+                type: object
+              version:
+                description: Version is the value of the Version field in the Chart.yaml
+                  of the deployed chart. e.g. 1.0.0.
+                type: string
+            required:
+            - appVersion
+            - release
+            - version
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/crds/crds.go
+++ b/pkg/crds/crds.go
@@ -1,0 +1,30 @@
+package crds
+
+import (
+	_ "embed"
+)
+
+//go:embed appcatalogentries.yaml
+var appCatalogEntries string
+
+//go:embed appcatalogs.yaml
+var appCatalogs string
+
+//go:embed apps.yaml
+var apps string
+
+//go:embed catalogs.yaml
+var catalogs string
+
+//go:embed charts.yaml
+var charts string
+
+func CRDs() []string {
+	return []string{
+		appCatalogEntries,
+		appCatalogs,
+		apps,
+		catalogs,
+		charts,
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18384

We changed how CRDs were ensured so they are fetched from [here](https://github.com/giantswarm/apiextensions/blob/14cbb7fc3e64558135830e8afb4c80af97c86d8d/helm/crds-common/templates/giantswarm.yaml) via the GitHub API.

The problem is we can hit the GitHub API rate limits. We added support for setting a GitHub token but this then needs to be wired into all the tests.

This changes the approach to embed the CRDs in the binary. We only need to install CRDs in the application group and they do not change frequently. 

## Checklist

- [x] Update changelog in CHANGELOG.md.
