### PR TITLE
Add --log-level flag and default to error level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `log-level` flag and default to `error` level.
+
 ### Changed
 
 - Use apiextensions-application to remove CAPI dependency.

--- a/cmd/bootstrap/flag.go
+++ b/cmd/bootstrap/flag.go
@@ -12,6 +12,7 @@ const (
 	kubeconfig       = "kubeconfig"
 	kubeconfigEnvVar = "KUBECONFIG"
 	kubeconfigPath   = "kubeconfig-path"
+	logLevel         = "log-level"
 	wait             = "wait"
 )
 
@@ -19,6 +20,7 @@ type flag struct {
 	InstallOperators bool
 	KubeConfig       string
 	KubeConfigPath   string
+	LogLevel         string
 	Wait             bool
 }
 
@@ -26,6 +28,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&f.InstallOperators, installOperators, "o", true, "Install app-operator and chart-operator")
 	cmd.Flags().StringVarP(&f.KubeConfig, kubeconfig, "k", "", "Explicit kubeconfig for the target cluster")
 	cmd.Flags().StringVarP(&f.KubeConfigPath, kubeconfigPath, "p", "", "Path to a kubeconfig file for the target cluster")
+	cmd.Flags().StringVarP(&f.LogLevel, logLevel, "l", "error", "Log level to be used for debug logging. Either debug, info, warning or error.")
 	cmd.Flags().BoolVarP(&f.Wait, wait, "w", true, "Wait for all components to be ready")
 }
 
@@ -35,6 +38,19 @@ func (f *flag) Validate() error {
 	} else if f.KubeConfig != "" && f.KubeConfigPath != "" {
 		return microerror.Maskf(invalidFlagError, "both --%s or --%s must not be set", kubeconfig, kubeconfigPath)
 	}
+	if !containsString([]string{"", "debug", "info", "warning", "error"}, f.LogLevel) {
+		return microerror.Maskf(invalidFlagError, "Log Level must be either of debug, info, warning or error.")
+	}
 
 	return nil
+}
+
+func containsString(list []string, s string) bool {
+	for _, l := range list {
+		if l == s {
+			return true
+		}
+	}
+
+	return false
 }

--- a/cmd/bootstrap/flag.go
+++ b/cmd/bootstrap/flag.go
@@ -39,7 +39,7 @@ func (f *flag) Validate() error {
 		return microerror.Maskf(invalidFlagError, "both --%s or --%s must not be set", kubeconfig, kubeconfigPath)
 	}
 	if !containsString([]string{"", "debug", "info", "warning", "error"}, f.LogLevel) {
-		return microerror.Maskf(invalidFlagError, "Log Level must be either of debug, info, warning or error.")
+		return microerror.Maskf(invalidFlagError, "Log level must be either debug, info, warning or error.")
 	}
 
 	return nil


### PR DESCRIPTION
Current logs are noisy and I'm sure everyone got bored reading them a while back.

This adds a `--log-level` flag which defaults to `error` and these new log messages.

```sh
$ apptestctl bootstrap --kubeconfig="$(kind get kubeconfig)"
bootstrapping app platform components
app platform components are ready
```

## Checklist

- [x] Update changelog in CHANGELOG.md.
