### PR TITLE
Fix install-operators flag so it doesn't wait for chartmuseum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use apiextensions-application to remove CAPI dependency.
 - Upgrade helm to v3.6.3.
 
+### Fixed
+
+- Fix `--install-operators` flag so it doesn't wait for `chartmuseum`.
+
 ## [0.12.0] - 2021-10-04
 
 ### Changed

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -201,13 +201,15 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 
-	if r.flag.InstallOperators {
-		err = r.installOperators(ctx, helmClient, k8sClients)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "skipping installing operators")
+	// If --install-operators is false we stop here. This is useful when we
+	// don't want to use the pinned app-operator and chart-operator versions.
+	if !r.flag.InstallOperators {
+		fmt.Fprintln(r.stdout, "skipping installing operators")
+	}
+
+	err = r.installOperators(ctx, helmClient, k8sClients)
+	if err != nil {
+		return microerror.Mask(err)
 	}
 
 	err = r.installCatalogs(ctx, k8sClients)


### PR DESCRIPTION
Needed for https://github.com/giantswarm/app-operator/pull/892

We're hitting the GitHub rate limits in app-operator tests installing CRDs. We can use `apptestctl bootstrap --install-operators=false` instead and the CRDs are embedded so we don't hit any limits. 🎉 

But currently it fails because we create the chartmuseum app CR 🤦‍♂️ 

## Checklist

- [x] Update changelog in CHANGELOG.md.
