### PR TITLE
Upgrade versions + conditionally install PSPs for 1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added support for kubernetes 1.25
+- Upgrade app-operator to version 6.7.0
+- Upgrade chart-operator to version 2.35.0
+- Upgrade chartmuseum chart to version 3.9.3
+
 ## [0.15.0] - 2023-04-28
 
 ### Added

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -38,14 +38,15 @@ import (
 )
 
 const (
-	appOperatorVersion            = "6.6.4-a43507ccde1a9e91f0ce44fe4f1d74515daa4152"
-	chartMuseumCatalogName        = "chartmuseum"
-	chartMuseumCatalogStorageURL  = "https://chartmuseum.github.io/charts"
-	chartMuseumName               = "chartmuseum"
-	chartMuseumVersion            = "3.9.3"
-	chartOperatorVersion          = "2.35.0"
-	controlPlaneCatalogStorageURL = "https://giantswarm.github.io/control-plane-test-catalog/"
-	namespace                     = "giantswarm"
+	appOperatorVersion             = "6.6.4-a43507ccde1a9e91f0ce44fe4f1d74515daa4152"
+	chartMuseumCatalogHelmIndexURL = "https://chartmuseum.github.io/charts"
+	chartMuseumCatalogName         = "apptestctl-chartmuseum"
+	chartMuseumCatalogStorageURL   = "http://chartmuseum:8080/charts/"
+	chartMuseumName                = "chartmuseum"
+	chartMuseumVersion             = "3.9.3"
+	chartOperatorVersion           = "2.35.0"
+	controlPlaneCatalogStorageURL  = "https://giantswarm.github.io/control-plane-test-catalog/"
+	namespace                      = "giantswarm"
 )
 
 type runner struct {
@@ -559,7 +560,7 @@ func (r *runner) installChartMuseum(ctx context.Context, appTest apptest.Interfa
 		apps := []apptest.App{
 			{
 				CatalogName:   chartMuseumCatalogName,
-				CatalogURL:    chartMuseumCatalogStorageURL,
+				CatalogURL:    chartMuseumCatalogHelmIndexURL,
 				Name:          chartMuseumName,
 				Namespace:     namespace,
 				ValuesYAML:    chartMuseumValuesYAML,

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -38,14 +38,14 @@ import (
 )
 
 const (
-	appOperatorVersion             = "6.6.4-a43507ccde1a9e91f0ce44fe4f1d74515daa4152"
+	appOperatorVersion             = "6.7.0"
 	chartMuseumCatalogHelmIndexURL = "https://chartmuseum.github.io/charts"
 	chartMuseumCatalogName         = "apptestctl-chartmuseum"
 	chartMuseumCatalogStorageURL   = "http://chartmuseum:8080/"
 	chartMuseumName                = "chartmuseum"
 	chartMuseumVersion             = "3.9.3"
 	chartOperatorVersion           = "2.35.0"
-	controlPlaneCatalogStorageURL  = "https://giantswarm.github.io/control-plane-test-catalog/"
+	controlPlaneCatalogStorageURL  = "https://giantswarm.github.io/control-plane-catalog/"
 	namespace                      = "giantswarm"
 )
 

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -13,7 +13,6 @@ import (
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/helmclient/v4/pkg/helmclient"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
-	"github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/to"
@@ -39,14 +38,13 @@ import (
 )
 
 const (
-	appOperatorVersion            = "5.4.0"
+	appOperatorVersion            = "6.6.4-a43507ccde1a9e91f0ce44fe4f1d74515daa4152"
+	chartMuseumCatalogName        = "chartmuseum"
+	chartMuseumCatalogStorageURL  = "https://chartmuseum.github.io/charts"
 	chartMuseumName               = "chartmuseum"
-	chartMuseumCatalogStorageURL  = "http://chartmuseum-chartmuseum:8080/charts/"
-	chartMuseumVersion            = "2.13.3"
-	chartOperatorVersion          = "2.20.0"
-	controlPlaneCatalogStorageURL = "https://giantswarm.github.io/control-plane-catalog/"
-	helmStableCatalogName         = "helm-stable"
-	helmStableCatalogStorageURL   = "https://charts.helm.sh/stable/packages/"
+	chartMuseumVersion            = "3.9.3"
+	chartOperatorVersion          = "2.35.0"
+	controlPlaneCatalogStorageURL = "https://giantswarm.github.io/control-plane-test-catalog/"
 	namespace                     = "giantswarm"
 )
 
@@ -219,7 +217,12 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 
-	err = r.ensureChartMuseumPSP(ctx, k8sClients)
+	hasPSP, err := r.hasPSP(ctx, k8sClients)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.ensureChartMuseumPSP(ctx, k8sClients, hasPSP)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -354,9 +357,6 @@ func (r *runner) installCatalogs(ctx context.Context, k8sClients k8sclient.Inter
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: metav1.NamespaceDefault,
-				Labels: map[string]string{
-					label.CatalogVisibility: "internal",
-				},
 			},
 			Spec: v1alpha1.CatalogSpec{
 				Description: name,
@@ -386,89 +386,111 @@ func (r *runner) installCatalogs(ctx context.Context, k8sClients k8sclient.Inter
 	return nil
 }
 
-func (r *runner) ensureChartMuseumPSP(ctx context.Context, k8sClients k8sclient.Interface) error {
+func (r *runner) hasPSP(ctx context.Context, k8sClients k8sclient.Interface) (bool, error) {
+
+	list, err := k8sClients.K8sClient().Discovery().ServerGroups()
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	for _, group := range list.Groups {
+		if group.Name == "policy" {
+			for _, gv := range group.Versions {
+				if gv.GroupVersion == "policy/v1beta1" {
+					return true, nil
+				}
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func (r *runner) ensureChartMuseumPSP(ctx context.Context, k8sClients k8sclient.Interface, installPSP bool) error {
 	name := "chartmuseum-psp"
-	r.logger.Debugf(ctx, "ensuring psp %#q", name)
+	r.logger.Debugf(ctx, "ensuring additional chartmuseum resources %#q", name)
 
 	o := func() error {
-		{
-			clusterRole := &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
-				Rules: []rbacv1.PolicyRule{
-					{
-						APIGroups:     []string{"extensions"},
-						Resources:     []string{"podsecuritypolicies"},
-						ResourceNames: []string{name},
-						Verbs:         []string{"use"},
+		if installPSP {
+			{
+				clusterRole := &rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: name,
 					},
-				},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{"extensions"},
+							Resources:     []string{"podsecuritypolicies"},
+							ResourceNames: []string{name},
+							Verbs:         []string{"use"},
+						},
+					},
+				}
+				_, err := k8sClients.K8sClient().RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
+				if apierrors.IsAlreadyExists(err) {
+					r.logger.Debugf(ctx, "clusterRole %#q already exists", name)
+					// fall through
+				} else if err != nil {
+					return microerror.Mask(err)
+				}
 			}
-			_, err := k8sClients.K8sClient().RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
-			if apierrors.IsAlreadyExists(err) {
-				r.logger.Debugf(ctx, "clusterRole %#q already exists", name)
-				// fall through
-			} else if err != nil {
-				return microerror.Mask(err)
+			{
+				clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: name,
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							Kind:      "ServiceAccount",
+							Name:      "chartmuseum",
+							Namespace: namespace,
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						Kind:     "ClusterRole",
+						Name:     name,
+						APIGroup: "rbac.authorization.k8s.io",
+					},
+				}
+				_, err := k8sClients.K8sClient().RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
+				if apierrors.IsAlreadyExists(err) {
+					r.logger.Debugf(ctx, "clusterRoleBinding %#q already exists", name)
+					// fall through
+				} else if err != nil {
+					return microerror.Mask(err)
+				}
 			}
-		}
-		{
-			clusterRoleBinding := &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
-				Subjects: []rbacv1.Subject{
-					{
-						Kind:      "ServiceAccount",
-						Name:      "chartmuseum",
-						Namespace: namespace,
+			{
+				psp := &policyv1beta1.PodSecurityPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: name,
 					},
-				},
-				RoleRef: rbacv1.RoleRef{
-					Kind:     "ClusterRole",
-					Name:     name,
-					APIGroup: "rbac.authorization.k8s.io",
-				},
-			}
-			_, err := k8sClients.K8sClient().RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
-			if apierrors.IsAlreadyExists(err) {
-				r.logger.Debugf(ctx, "clusterRoleBinding %#q already exists", name)
-				// fall through
-			} else if err != nil {
-				return microerror.Mask(err)
-			}
-		}
-		{
-			psp := &policyv1beta1.PodSecurityPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
-				Spec: policyv1beta1.PodSecurityPolicySpec{
-					AllowPrivilegeEscalation: to.BoolP(true),
-					Volumes: []policyv1beta1.FSType{
-						policyv1beta1.All,
+					Spec: policyv1beta1.PodSecurityPolicySpec{
+						AllowPrivilegeEscalation: to.BoolP(true),
+						Volumes: []policyv1beta1.FSType{
+							policyv1beta1.All,
+						},
+						RunAsUser: policyv1beta1.RunAsUserStrategyOptions{
+							Rule: policyv1beta1.RunAsUserStrategyRunAsAny,
+						},
+						SupplementalGroups: policyv1beta1.SupplementalGroupsStrategyOptions{
+							Rule: policyv1beta1.SupplementalGroupsStrategyRunAsAny,
+						},
+						FSGroup: policyv1beta1.FSGroupStrategyOptions{
+							Rule: policyv1beta1.FSGroupStrategyRunAsAny,
+						},
+						SELinux: policyv1beta1.SELinuxStrategyOptions{
+							Rule: policyv1beta1.SELinuxStrategyRunAsAny,
+						},
 					},
-					RunAsUser: policyv1beta1.RunAsUserStrategyOptions{
-						Rule: policyv1beta1.RunAsUserStrategyRunAsAny,
-					},
-					SupplementalGroups: policyv1beta1.SupplementalGroupsStrategyOptions{
-						Rule: policyv1beta1.SupplementalGroupsStrategyRunAsAny,
-					},
-					FSGroup: policyv1beta1.FSGroupStrategyOptions{
-						Rule: policyv1beta1.FSGroupStrategyRunAsAny,
-					},
-					SELinux: policyv1beta1.SELinuxStrategyOptions{
-						Rule: policyv1beta1.SELinuxStrategyRunAsAny,
-					},
-				},
-			}
-			_, err := k8sClients.K8sClient().PolicyV1beta1().PodSecurityPolicies().Create(ctx, psp, metav1.CreateOptions{})
-			if apierrors.IsAlreadyExists(err) {
-				r.logger.Debugf(ctx, "psp %#q already exists", name)
-				// fall through
-			} else if err != nil {
-				return microerror.Mask(err)
+				}
+				_, err := k8sClients.K8sClient().PolicyV1beta1().PodSecurityPolicies().Create(ctx, psp, metav1.CreateOptions{})
+				if apierrors.IsAlreadyExists(err) {
+					r.logger.Debugf(ctx, "psp %#q already exists", name)
+					// fall through
+				} else if err != nil {
+					return microerror.Mask(err)
+				}
 			}
 		}
 
@@ -523,7 +545,7 @@ func (r *runner) ensureChartMuseumPSP(ctx context.Context, k8sClients k8sclient.
 		return microerror.Mask(err)
 	}
 
-	r.logger.Debugf(ctx, "ensured psp %#q", name)
+	r.logger.Debugf(ctx, "ensured additional chartmuseum resources %#q", name)
 
 	return nil
 }
@@ -536,8 +558,8 @@ func (r *runner) installChartMuseum(ctx context.Context, appTest apptest.Interfa
 
 		apps := []apptest.App{
 			{
-				CatalogName:   helmStableCatalogName,
-				CatalogURL:    helmStableCatalogStorageURL,
+				CatalogName:   chartMuseumCatalogName,
+				CatalogURL:    chartMuseumCatalogStorageURL,
 				Name:          chartMuseumName,
 				Namespace:     namespace,
 				ValuesYAML:    chartMuseumValuesYAML,
@@ -642,7 +664,7 @@ func (r *runner) installOperator(ctx context.Context, helmClient helmclient.Inte
 func (r *runner) waitForChartMuseum(ctx context.Context, appTest apptest.Interface) error {
 	var err error
 
-	deployName := fmt.Sprintf("%s-%s", chartMuseumName, chartMuseumName)
+	deployName := chartMuseumName
 
 	r.logger.Debugf(ctx, "waiting for ready %#q deployment", deployName)
 

--- a/cmd/bootstrap/runner.go
+++ b/cmd/bootstrap/runner.go
@@ -41,7 +41,7 @@ const (
 	appOperatorVersion             = "6.6.4-a43507ccde1a9e91f0ce44fe4f1d74515daa4152"
 	chartMuseumCatalogHelmIndexURL = "https://chartmuseum.github.io/charts"
 	chartMuseumCatalogName         = "apptestctl-chartmuseum"
-	chartMuseumCatalogStorageURL   = "http://chartmuseum:8080/charts/"
+	chartMuseumCatalogStorageURL   = "http://chartmuseum:8080/"
 	chartMuseumName                = "chartmuseum"
 	chartMuseumVersion             = "3.9.3"
 	chartOperatorVersion           = "2.35.0"

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/giantswarm/helmclient/v4 v4.11.2
 	github.com/giantswarm/k8sclient/v6 v6.1.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8smetadata v0.20.0
 	github.com/giantswarm/microerror v0.4.0
 	github.com/giantswarm/micrologger v1.0.0
 	github.com/giantswarm/to v0.4.0
@@ -50,6 +49,7 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/color v1.13.0 // indirect
+	github.com/giantswarm/k8smetadata v0.20.0 // indirect
 	github.com/giantswarm/kubeconfig/v4 v4.1.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-gorp/gorp/v3 v3.0.2 // indirect


### PR DESCRIPTION
This PR tries to update apptestctl for kubernetes 1.25

- Added support for kubernetes 1.25
- Upgrade app-operator to version 6.7.0
- Upgrade chart-operator to version 2.35.0
- Upgrade chartmuseum chart to version 3.9.3

## Checklist

- [x] Update changelog in CHANGELOG.md.
