### PR TITLE
feat(ci): release darwin and windows binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@6.15.0
+  architect: giantswarm/architect@9.1.0
 
 workflows:
   test:
@@ -10,6 +10,7 @@ workflows:
         context: architect
         name: go-build-apptestctl
         binary: apptestctl
+        architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
         filters:
             # Trigger job also on git tag.
           tags:
@@ -18,6 +19,7 @@ workflows:
     - architect/push-to-registries:
         context: architect
         name: push-to-registries
+        platforms: "linux/amd64,linux/arm64"
         requires:
         - go-build-apptestctl
         filters:
@@ -29,6 +31,19 @@ workflows:
             ignore:
             - main
             - master
+
+    - architect/upload-release-assets:
+        context: architect
+        name: upload-release-assets
+        binary: apptestctl
+        requires:
+        - go-build-apptestctl
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
+
     - architect/integration-test:
         context: architect
         name: integration-test-bootstrap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `apptestctl-windows-<arch>.exe`.
+
 ## [0.25.1] - 2026-05-26
 
 ### Changed


### PR DESCRIPTION
## What

- `go-build`: adds `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64` to the `architectures` list.
- `push-to-registries`: pins `platforms: "linux/amd64,linux/arm64"` so the non-linux entries written to `.platforms` by `go-build` don't propagate to the Docker buildx build.
- `upload-release-assets`: new job; uploads binaries and cosign `.bundle` files to the GitHub Release on tags.
- Bumps architect orb 6.15.0 to 9.1.0, which names Windows binaries `<binary>-windows-<arch>.exe` and adds cosign keyless signing and SBOM attestations.

Same pattern as giantswarm/muster#796.