### PR TITLE
fix(ci): use arch-specific binary in Dockerfile for multiarch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM gsoci.azurecr.io/giantswarm/alpine:3.20.3-giantswarm
 
+ARG TARGETARCH
+
 USER giantswarm
-COPY ./apptestctl /usr/local/bin/apptestctl
+COPY ./apptestctl-linux-${TARGETARCH} /usr/local/bin/apptestctl
 
 ENTRYPOINT ["apptestctl"]


### PR DESCRIPTION
## What

Fixes the Dockerfile to copy the arch-specific binary produced by \`architect/go-build\` instead of the linux/amd64-only backward-compatibility copy.

\`architect/go-build\` produces \`<binary>-linux-amd64\` and \`<binary>-linux-arm64\` (plus a \`<binary>\` compat copy for linux/amd64 only). With \`platforms: "linux/amd64,linux/arm64"\` in \`push-to-registries\`, buildx runs the Dockerfile for each platform — the arm64 build was silently getting the amd64 binary from the compat copy.

Adding \`ARG TARGETARCH\` and using \`<binary>-linux-\${TARGETARCH}\` ensures each platform build picks up the correct binary.

Followup to the orb 9.1.0 / multiarch release PR merged earlier today.