### PR TITLE
chore: replace decommissioned giantswarmpublic.azurecr.io registry

### DIFF
--- a/hack/sync-crds.sh
+++ b/hack/sync-crds.sh
@@ -35,4 +35,4 @@ curl -s "https://raw.githubusercontent.com/giantswarm/prometheus-meta-operator/m
 
 # Gateway API + Gateway API Inference Extension
 # keep the version aligned with the version in giantswarm/gateway-api-bundle
-helm template oci://giantswarmpublic.azurecr.io/giantswarm-catalog/gateway-api-crds:1.4.0 --set install.inferencepools=standard > "../pkg/crds/gateway-api.yaml"
+helm template oci://gsoci.azurecr.io/charts/giantswarm/gateway-api-crds:1.4.0 --set install.inferencepools=standard > "../pkg/crds/gateway-api.yaml"


### PR DESCRIPTION
The container registry `giantswarmpublic.azurecr.io`, which hosted the Giant Swarm Helm chart catalogs, has been decommissioned. All chart catalogs are now consolidated onto `oci://gsoci.azurecr.io/charts/giantswarm/<chart>`.

This PR updates `hack/sync-crds.sh` so the `gateway-api-crds` chart resolves from `gsoci.azurecr.io` instead of the retired `giantswarmpublic.azurecr.io` registry.

## Checklist

- [ ] Update changelog in CHANGELOG.md.